### PR TITLE
The bot will now also alert twd_getintoteaching of incidents

### DIFF
--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -31,6 +31,11 @@ class SlackIncidentActions
                               text: ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{incident_title.capitalize} \n>*Priority:* #{incident_priority}\n>*Comms:* <##{channel_name}>")
     end
 
+    threads << Thread.new do
+      client.chat_postMessage(channel: 'twd_getintoteaching',
+                              text: ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{incident_title.capitalize} \n>*Priority:* #{incident_priority}\n>*Comms:* <##{channel_name}>")
+    end
+
     message = client.chat_postMessage(channel: channel_name,
                                       text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
     threads << Thread.new { client.pins_add(channel: channel_name, timestamp: message[:ts]) }

--- a/bot/slash_commands/close.rb
+++ b/bot/slash_commands/close.rb
@@ -12,6 +12,7 @@ SlackRubyBotServer::Events.configure do |config|
           message = slack_client.chat_postMessage(channel: channel_id, text: "<!here> This incident has now closed.")
           slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
           slack_client.chat_postMessage(channel: 'twd_bat', text: ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
+          slack_client.chat_postMessage(channel: 'twd_getintoteaching', text: ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
           { text: 'You’ve closed the incident.' }
         else
           {text: 'This is not an incident channel.'}

--- a/spec/bot/actions/slack_incident_actions_spec.rb
+++ b/spec/bot/actions/slack_incident_actions_spec.rb
@@ -46,7 +46,7 @@ describe 'actions/slack_incident_actions' do
     expect(conversation_stub).to have_been_requested
     expect(invite_stub).to have_been_requested
     expect(topic_stub).to have_been_requested
-    expect(message_stub).to have_been_requested.times(3)
+    expect(message_stub).to have_been_requested.times(4)
     expect(pin_stub).to have_been_requested
   end
 


### PR DESCRIPTION
A request has come through to get the bot to also alert the `twd_getintoteaching` channel when a new incident has been opened and when it is closed.