### PR TITLE
Bot fix - pass in channel id

### DIFF
--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -8,16 +8,17 @@ class SlackIncidentActions
     incident = SlackIncidentModal.new(slack_action)
     start_time = Time.zone.now.strftime('%y%m%d')
     channel_name = "incident_#{incident.service.downcase}_#{start_time}_#{incident.title.parameterize.underscore}"
+    channel = create_channel!(channel_name)
+    channel_id = channel[:channel][:id]
 
     threads = []
 
-    threads << Thread.new { create_channel!(channel_name) }
-    threads << Thread.new { invite_users!(channel_name, incident.leads) }
-    threads << Thread.new { set_channel_details!(channel_name, summary_for(incident)) }
-    threads << Thread.new { introduce_incident!(channel_name, incident.tech_lead) }
+    threads << Thread.new { invite_users!(channel_id, incident.leads) }
+    threads << Thread.new { set_channel_details!(channel_id, summary_for(incident)) }
+    threads << Thread.new { introduce_incident!(channel_id, incident.tech_lead) }
 
     CHANNELS_TO_NOTIFY.each do |channel_to_notify|
-      threads << Thread.new { notify_channel!(channel_to_notify, channel_name, incident.title, incident.priority) }
+      threads << Thread.new { notify_channel!(channel_to_notify, channel_id, incident.title, incident.priority) }
     end
 
     threads.each(&:join)
@@ -32,9 +33,9 @@ private
     )
   end
 
-  def invite_users!(channel_name, leads)
+  def invite_users!(channel_id, leads)
     slack_client.conversations_invite(
-      channel: channel_name,
+      channel: channel_id,
       users: leads.join(','),
     )
   end
@@ -43,25 +44,25 @@ private
     "Description: #{incident.description.capitalize}\n Priority: #{incident.priority}\n Comms lead: <@#{incident.comms_lead}>\n Tech lead: <@#{incident.tech_lead}>\n Support lead: <@#{incident.support_lead}>"
   end
 
-  def set_channel_details!(channel_name, summary)
+  def set_channel_details!(channel_id, summary)
     slack_client.conversations_setTopic(
-      channel: channel_name,
+      channel: channel_id,
       topic: summary,
     )
   end
 
-  def notify_channel!(channel, incident_channel_name, title, priority)
-    notification_text = ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{title.capitalize} \n>*Priority:* #{priority}\n>*Comms:* <##{incident_channel_name}>"
+  def notify_channel!(channel, incident_channel_id, title, priority)
+    notification_text = ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{title.capitalize} \n>*Priority:* #{priority}\n>*Comms:* <##{incident_channel_id}>"
 
     slack_client.chat_postMessage(channel: channel,
                                   text: notification_text)
   end
 
-  def introduce_incident!(channel_name, tech_lead)
-    message = slack_client.chat_postMessage(channel: channel_name,
+  def introduce_incident!(channel_id, tech_lead)
+    message = slack_client.chat_postMessage(channel: channel_id,
                                             text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
-    slack_client.pins_add(channel: channel_name, timestamp: message[:ts])
-    slack_client.chat_postMessage(channel: channel_name, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template> and consider starting a video call.")
+    slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
+    slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template> and consider starting a video call.")
   end
 
   def slack_client

--- a/config.ru
+++ b/config.ru
@@ -13,7 +13,7 @@ require 'erb'
 ActiveRecord::Base.establish_connection(
   YAML.safe_load(
     ERB.new(
-      File.read('config/postgresql.yml'),
+      File.read('config/database.yml'),
     ).result, [], [], true
   )[ENV['RACK_ENV']],
 )


### PR DESCRIPTION
the slack_client commands require the channel id, not the channel name