### PR TITLE
Create a SlackMethods object

### DIFF
--- a/app/models/slack_methods.rb
+++ b/app/models/slack_methods.rb
@@ -85,6 +85,6 @@ class SlackMethods
   end
 
   def self.slack_client
-    @_client ||= Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
+    @_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
   end
 end

--- a/app/models/slack_methods.rb
+++ b/app/models/slack_methods.rb
@@ -1,0 +1,90 @@
+class SlackMethods
+  def self.post_a_message(channel, text)
+    slack_client.chat_postMessage(
+      channel: channel,
+      text: text,
+    )
+  end
+
+  def self.pin_a_message(channel, timestamp)
+    slack_client.pins_add(
+      channel: channel,
+      timestamp: timestamp,
+    )
+  end
+
+  def self.post_a_message_to_user(channel, user, text)
+    slack_client.chat_postEphemeral(
+      channel: channel,
+      user: user,
+      text: text,
+    )
+  end
+
+  def self.current_summary(channel_id)
+    slack_client.conversations_info(
+      channel: channel_id,
+    ).dig(:channel, :topic, :value)
+  end
+
+  def self.current_members(channel_id)
+    slack_client.conversations_members(
+      channel: channel_id,
+    ).members
+  end
+
+  def self.create_channel!(channel_name)
+    slack_client.conversations_create(
+      name: channel_name,
+      is_private: false,
+    )
+  end
+
+  def self.invite_users!(channel_id, leads)
+    slack_client.conversations_invite(
+      channel: channel_id,
+      users: leads.join(','),
+    )
+  end
+
+  def self.summary_for(incident)
+    "Description: #{incident.description.capitalize}\n Priority: #{incident.priority}\n Comms lead: <@#{incident.comms_lead}>\n Tech lead: <@#{incident.tech_lead}>\n Support lead: <@#{incident.support_lead}>"
+  end
+
+  def self.set_channel_details!(channel_id, summary)
+    slack_client.conversations_setTopic(
+      channel: channel_id,
+      topic: summary,
+    )
+  end
+
+  def self.notify_channel!(channel, incident_channel_id, title, priority)
+    notification_text = ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{title.capitalize} \n>*Priority:* #{priority}\n>*Comms:* <##{incident_channel_id}>"
+
+    slack_client.chat_postMessage(channel: channel,
+                                  text: notification_text)
+  end
+
+  def self.notify_channel_of_update!(channel_id)
+    slack_client.chat_postMessage(channel: channel_id,
+                                  text: 'Incident has been updated')
+  end
+
+  def self.introduce_incident!(channel_id, tech_lead)
+    message = slack_client.chat_postMessage(channel: channel_id,
+                                            text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
+    slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
+    slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template> and consider starting a video call.")
+  end
+
+  def self.open_the_modal(trigger_id, view_payload)
+    slack_client.views_open(
+      trigger_id: trigger_id,
+      view: view_payload,
+    )
+  end
+
+  def self.slack_client
+    @_client ||= Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
+  end
+end

--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -8,17 +8,17 @@ class SlackIncidentActions
     incident = SlackIncidentModal.new(slack_action)
     start_time = Time.zone.now.strftime('%y%m%d')
     channel_name = "incident_#{incident.service.downcase}_#{start_time}_#{incident.title.parameterize.underscore}"
-    channel = create_channel!(channel_name)
+    channel = SlackMethods.create_channel!(channel_name)
     channel_id = channel[:channel][:id]
 
     threads = []
 
-    threads << Thread.new { invite_users!(channel_id, incident.leads) }
-    threads << Thread.new { set_channel_details!(channel_id, summary_for(incident)) }
-    threads << Thread.new { introduce_incident!(channel_id, incident.tech_lead) }
+    threads << Thread.new { SlackMethods.invite_users!(channel_id, incident.leads) }
+    threads << Thread.new { SlackMethods.set_channel_details!(channel_id, SlackMethods.summary_for(incident)) }
+    threads << Thread.new { SlackMethods.introduce_incident!(channel_id, incident.tech_lead) }
 
     CHANNELS_TO_NOTIFY.each do |channel_to_notify|
-      threads << Thread.new { notify_channel!(channel_to_notify, channel_id, incident.title, incident.priority) }
+      threads << Thread.new { SlackMethods.notify_channel!(channel_to_notify, channel_id, incident.title, incident.priority) }
     end
 
     threads.each(&:join)
@@ -26,86 +26,24 @@ class SlackIncidentActions
 
   def update_incident(slack_action, channel_id)
     incident = SlackUpdateModal.new(slack_action)
-    current_summary = current_summary(channel_id)
+    current_summary = SlackMethods.current_summary(channel_id)
 
     updated_summary = incident.summary_text(current_summary)
 
-    current_members = current_members(channel_id)
+    current_members = SlackMethods.current_members(channel_id)
 
     user_invite_list = incident.create_member_invite_list(current_members)
 
     threads = []
     unless updated_summary == current_summary
-      threads << Thread.new { set_channel_details!(channel_id, updated_summary) }
-      threads << Thread.new { notify_channel_of_update!(channel_id) }
+      threads << Thread.new { SlackMethods.set_channel_details!(channel_id, updated_summary) }
+      threads << Thread.new { SlackMethods.notify_channel_of_update!(channel_id) }
     end
 
     unless user_invite_list.compact.empty?
-      threads << Thread.new { invite_users!(channel_id, user_invite_list) }
+      threads << Thread.new { SlackMethods.invite_users!(channel_id, user_invite_list) }
     end
 
     threads.each(&:join)
-  end
-
-private
-
-  def current_summary(channel_id)
-    slack_client.conversations_info(
-      channel: channel_id,
-    ).dig(:channel, :topic, :value)
-  end
-
-  def current_members(channel_id)
-    slack_client.conversations_members(
-      channel: channel_id,
-    ).members
-  end
-
-  def create_channel!(channel_name)
-    slack_client.conversations_create(
-      name: channel_name,
-      is_private: false,
-    )
-  end
-
-  def invite_users!(channel_id, leads)
-    slack_client.conversations_invite(
-      channel: channel_id,
-      users: leads.join(','),
-    )
-  end
-
-  def summary_for(incident)
-    "Description: #{incident.description.capitalize}\n Priority: #{incident.priority}\n Comms lead: <@#{incident.comms_lead}>\n Tech lead: <@#{incident.tech_lead}>\n Support lead: <@#{incident.support_lead}>"
-  end
-
-  def set_channel_details!(channel_id, summary)
-    slack_client.conversations_setTopic(
-      channel: channel_id,
-      topic: summary,
-    )
-  end
-
-  def notify_channel!(channel, incident_channel_id, title, priority)
-    notification_text = ":rotating_light: <!channel> A new incident has been opened :rotating_light:\n> *Title:* #{title.capitalize} \n>*Priority:* #{priority}\n>*Comms:* <##{incident_channel_id}>"
-
-    slack_client.chat_postMessage(channel: channel,
-                                  text: notification_text)
-  end
-
-  def notify_channel_of_update!(channel_id)
-    slack_client.chat_postMessage(channel: channel_id,
-                                  text: 'Incident has been updated')
-  end
-
-  def introduce_incident!(channel_id, tech_lead)
-    message = slack_client.chat_postMessage(channel: channel_id,
-                                            text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
-    slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
-    slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template> and consider starting a video call.")
-  end
-
-  def slack_client
-    @_client ||= Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
   end
 end

--- a/bot/actions/slack_incident_listener.rb
+++ b/bot/actions/slack_incident_listener.rb
@@ -12,17 +12,23 @@ SlackRubyBotServer::Events.configure do |config|
         end
       end
     rescue Slack::Web::Api::Errors::NameTaken
-      slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
-      slack_client.chat_postEphemeral(channel: action[:payload][:user][:id], user: action[:payload][:user][:id],
-                                      text: 'That incident channel name has already been taken. Please try another.')
+      SlackMethods.post_a_message_to_user(
+        user_id,
+        user_id,
+        'That incident channel name has already been taken. Please try another.',
+      )
     rescue Slack::Web::Api::Errors::CantInviteSelf
-      slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
-      slack_client.chat_postEphemeral(channel: action[:payload][:user][:id], user: action[:payload][:user][:id],
-                                      text: 'You can’t invite the bot to the channel. You’ll need to manually add the leads now.')
+      SlackMethods.post_a_message_to_user(
+        user_id,
+        user_id,
+        'You can’t invite the bot to the channel. You’ll need to manually add the leads now.',
+      )
     rescue Slack::Web::Api::Errors::TooLong
-      slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
-      slack_client.chat_postEphemeral(channel: action[:payload][:user][:id], user: action[:payload][:user][:id],
-                                      text: 'Your incident description was too long. You’ll need to manually add it now.')
+      SlackMethods.post_a_message_to_user(
+        user_id,
+        user_id,
+        'Your incident description was too long. You’ll need to manually add it now.',
+      )
     end
     nil
   end

--- a/bot/slash_commands/close.rb
+++ b/bot/slash_commands/close.rb
@@ -2,16 +2,16 @@ SlackRubyBotServer::Events.configure do |config|
   config.on :command, '/closeincident' do |command|
     channel_name = command[:channel_name]
     channel_id = command[:channel_id]
-    command.logger.info "Closing the incident in #{channel_name}."
-
-    slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
 
     begin
       if channel_name.include? 'incident'
-        message = slack_client.chat_postMessage(channel: channel_id, text: '<!here> This incident has now closed.')
-        slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
-        slack_client.chat_postMessage(channel: 'twd_git_bat', text: ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
-        slack_client.chat_postMessage(channel: 'twd_getintoteaching', text: ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
+        message = SlackMethods.post_a_message(channel_id, '<!here> This incident has now closed.')
+
+        SlackMethods.pin_a_message(channel_id, message[:ts])
+
+        SlackMethods.post_a_message('twd_git_bat', ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
+        SlackMethods.post_a_message('twd_getintoteaching', ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
+
         { text: 'You’ve closed the incident.' }
       else
         { text: 'This is not an incident channel.' }

--- a/bot/slash_commands/incident.rb
+++ b/bot/slash_commands/incident.rb
@@ -1,14 +1,8 @@
 SlackRubyBotServer::Events.configure do |config|
   config.on :command, '/incident' do |command|
-    command.logger.info "Someone raised an incident in channel #{command[:channel_name]}."
-    slack_connection(command)
+    SlackMethods.open_the_modal(command[:trigger_id], incident_payload)
     nil
   end
-end
-
-def slack_connection(trigger_id, view = incident_payload)
-  slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
-  slack_client.views_open(trigger_id: trigger_id[:trigger_id], view: view)
 end
 
 def incident_payload

--- a/bot/slash_commands/update.rb
+++ b/bot/slash_commands/update.rb
@@ -3,11 +3,9 @@ SlackRubyBotServer::Events.configure do |config|
     channel_name = command[:channel_name]
     channel_id = command[:channel_id]
 
-    slack_client = Slack::Web::Client.new(token: ENV['SLACK_TOKEN'])
-
     begin
       if channel_name.include? 'incident'
-        slack_client.views_open(trigger_id: command[:trigger_id], view: update_payload)
+        SlackMethods.open_the_modal(command[:trigger_id], update_payload)
         Rails.cache.write('channel', channel_id)
         { text: 'You’ve updated the incident.' }
       else

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,7 @@ require 'action_view/railtie'
 require 'action_cable/engine'
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require './app/models/slack_methods'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/spec/bot/slash_commands/close_spec.rb
+++ b/spec/bot/slash_commands/close_spec.rb
@@ -28,7 +28,6 @@ describe 'slash_commands/close' do
       end
 
       it 'returns incident closed confirmation' do
-        expect_any_instance_of(Logger).to receive(:info).with('Closing the incident in incident_channel_name.')
         post '/api/slack/command', command
         expect(last_response.status).to eq 201
         expect(JSON.parse(last_response.body)).to eq('text' => 'You’ve closed the incident.')
@@ -51,7 +50,6 @@ describe 'slash_commands/close' do
       end
 
       it 'returns incident closed confirmation' do
-        expect_any_instance_of(Logger).to receive(:info).with('Closing the incident in channel_name.')
         post '/api/slack/command', command
         expect(last_response.status).to eq 201
         expect(JSON.parse(last_response.body)).to eq('text' => 'This is not an incident channel.')

--- a/spec/bot/slash_commands/incident_spec.rb
+++ b/spec/bot/slash_commands/incident_spec.rb
@@ -29,7 +29,6 @@ describe 'slash_commands/incident' do
       end
 
       it 'successfully processes the request' do
-        allow_any_instance_of(Logger).to receive(:info).with("Someone raised an incident in channel #{command[:channel_name]}.")
         post '/api/slack/command', command
         expect(last_response.status).to eq 204
       end

--- a/spec/bot/slash_commands/update_spec.rb
+++ b/spec/bot/slash_commands/update_spec.rb
@@ -27,7 +27,6 @@ describe 'slash_command/update' do
     end
 
     it 'returns incident updated confirmation' do
-      allow_any_instance_of(Logger).to receive(:info).with('Updating the incident in incident_channel_name')
       post '/api/slack/command', command
       expect(last_response.status).to eq 201
       expect(JSON.parse(last_response.body)).to eq('text' => 'You’ve updated the incident.')
@@ -50,7 +49,6 @@ describe 'slash_command/update' do
     end
 
     it 'returns the error message' do
-      allow_any_instance_of(Logger).to receive(:info).with('Updating the incident in channel_name')
       post '/api/slack/command', command
       expect(last_response.status).to eq 201
       expect(JSON.parse(last_response.body)).to eq('text' => 'This is not an incident channel.')


### PR DESCRIPTION
## Context

Slack API methods are being used throughout the app – this moves them all under a single class that can be used instead

## Changes proposed in this pull request

- Create the SlackMethods class and extract the methods into it
- Update the app to call this instead