### PR TITLE
Use the channel that calls the bot as the one to update

### DIFF
--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -1,10 +1,5 @@
 class SlackIncidentActions
-  CHANNELS_TO_NOTIFY = %w[
-    twd_git_bat
-    twd_getintoteaching
-  ].freeze
-
-  def open_incident(slack_action)
+  def open_incident(slack_action, channel_calling_incident)
     incident = SlackIncidentModal.new(slack_action)
     start_time = Time.zone.now.strftime('%y%m%d')
     channel_name = "incident_#{incident.service.downcase}_#{start_time}_#{incident.title.parameterize.underscore}"
@@ -16,10 +11,7 @@ class SlackIncidentActions
     threads << Thread.new { SlackMethods.invite_users!(channel_id, incident.leads) }
     threads << Thread.new { SlackMethods.set_channel_details!(channel_id, SlackMethods.summary_for(incident)) }
     threads << Thread.new { SlackMethods.introduce_incident!(channel_id, incident.tech_lead) }
-
-    CHANNELS_TO_NOTIFY.each do |channel_to_notify|
-      threads << Thread.new { SlackMethods.notify_channel!(channel_to_notify, channel_id, incident.title, incident.priority) }
-    end
+    threads << Thread.new { SlackMethods.notify_channel!(channel_calling_incident, channel_id, incident.title, incident.priority) }
 
     threads.each(&:join)
   end

--- a/bot/actions/slack_incident_listener.rb
+++ b/bot/actions/slack_incident_listener.rb
@@ -8,26 +8,33 @@ SlackRubyBotServer::Events.configure do |config|
           channel_id = Rails.cache.read('channel')
           SlackIncidentActions.new.update_incident(action, channel_id)
         else
-          SlackIncidentActions.new.open_incident(action)
+          channel_calling_incident = Rails.cache.read('channel_calling_incident')
+          SlackIncidentActions.new.open_incident(action, channel_calling_incident)
         end
       end
     rescue Slack::Web::Api::Errors::NameTaken
       SlackMethods.post_a_message_to_user(
-        user_id,
-        user_id,
+        action[:payload][:user][:id],
+        action[:payload][:user][:id],
         'That incident channel name has already been taken. Please try another.',
       )
     rescue Slack::Web::Api::Errors::CantInviteSelf
       SlackMethods.post_a_message_to_user(
-        user_id,
-        user_id,
+        action[:payload][:user][:id],
+        action[:payload][:user][:id],
         'You can’t invite the bot to the channel. You’ll need to manually add the leads now.',
       )
     rescue Slack::Web::Api::Errors::TooLong
       SlackMethods.post_a_message_to_user(
-        user_id,
-        user_id,
+        action[:payload][:user][:id],
+        action[:payload][:user][:id],
         'Your incident description was too long. You’ll need to manually add it now.',
+      )
+    rescue Slack::Web::Api::Errors::NotInChannel
+      SlackMethods.post_a_message_to_user(
+        action[:payload][:user][:id],
+        action[:payload][:user][:id],
+        'The bot is not in this channel. You’ll need to manually alert it now.',
       )
     end
     nil

--- a/bot/slash_commands/close.rb
+++ b/bot/slash_commands/close.rb
@@ -6,11 +6,11 @@ SlackRubyBotServer::Events.configure do |config|
     begin
       if channel_name.include? 'incident'
         message = SlackMethods.post_a_message(channel_id, '<!here> This incident has now closed.')
+        channel_calling_incident = Rails.cache.read('channel_calling_incident')
 
         SlackMethods.pin_a_message(channel_id, message[:ts])
 
-        SlackMethods.post_a_message('twd_git_bat', ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
-        SlackMethods.post_a_message('twd_getintoteaching', ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
+        SlackMethods.post_a_message(channel_calling_incident, ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
 
         { text: 'You’ve closed the incident.' }
       else

--- a/bot/slash_commands/incident.rb
+++ b/bot/slash_commands/incident.rb
@@ -1,5 +1,6 @@
 SlackRubyBotServer::Events.configure do |config|
   config.on :command, '/incident' do |command|
+    Rails.cache.write('channel_calling_incident', command[:channel_id])
     SlackMethods.open_the_modal(command[:trigger_id], incident_payload)
     nil
   end

--- a/spec/bot/actions/slack_incident_actions_spec.rb
+++ b/spec/bot/actions/slack_incident_actions_spec.rb
@@ -63,11 +63,11 @@ describe 'actions/slack_incident_actions' do
                                                                                            headers: { 'Content-Type' => 'application/json' })
     pin_stub = stub_request(:post, 'https://slack.com/api/pins.add').to_return(status: 200, body: '', headers: {})
 
-    SlackIncidentActions.new.open_incident(incident_payload)
+    SlackIncidentActions.new.open_incident(incident_payload, channel_id)
     expect(conversation_stub).to have_been_requested
     expect(invite_stub).to have_been_requested
     expect(topic_stub).to have_been_requested
-    expect(message_stub).to have_been_requested.times(4)
+    expect(message_stub).to have_been_requested.times(3)
     expect(pin_stub).to have_been_requested
   end
 


### PR DESCRIPTION
## Context

Previously we specified two channels to post incident updates to.
This made the bot quite static, so it will now use the channel that
calls the bot initially, as the channel to post updates to.

## Changes proposed in this pull request

- Store another channel_id value to the Rails cache
- Use this instead of the hardcoded channels constant
