### PR TITLE
Get the Slack bot to start a Google meet

### DIFF
--- a/app/models/slack_methods.rb
+++ b/app/models/slack_methods.rb
@@ -74,7 +74,13 @@ class SlackMethods
     message = slack_client.chat_postMessage(channel: channel_id,
                                             text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
     slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
-    slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template> and consider starting a video call.")
+    slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template>.")
+  end
+
+  def self.start_meet!(channel_id)
+    message = slack_client.chat_postMessage(channel: channel_id,
+                                            text: "Join the <#{ENV['MEETS_LINK']}|incident call.>")
+    slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
   end
 
   def self.open_the_modal(trigger_id, view_payload)

--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -12,6 +12,7 @@ class SlackIncidentActions
     threads << Thread.new { SlackMethods.set_channel_details!(channel_id, SlackMethods.summary_for(incident)) }
     threads << Thread.new { SlackMethods.introduce_incident!(channel_id, incident.tech_lead) }
     threads << Thread.new { SlackMethods.notify_channel!(channel_calling_incident, channel_id, incident.title, incident.priority) }
+    threads << Thread.new { SlackMethods.start_meet!(channel_id) }
 
     threads.each(&:join)
   end

--- a/spec/bot/actions/slack_incident_actions_spec.rb
+++ b/spec/bot/actions/slack_incident_actions_spec.rb
@@ -67,8 +67,8 @@ describe 'actions/slack_incident_actions' do
     expect(conversation_stub).to have_been_requested
     expect(invite_stub).to have_been_requested
     expect(topic_stub).to have_been_requested
-    expect(message_stub).to have_been_requested.times(3)
-    expect(pin_stub).to have_been_requested
+    expect(message_stub).to have_been_requested.times(4)
+    expect(pin_stub).to have_been_requested.times(2)
   end
 
   it 'performs the update action' do


### PR DESCRIPTION
## Context

We want the Slack bot to also start a Google meet for the response team to jump on. Requires a Google meet link to be stored in the environment variables

## Changes proposed in this pull request

Add a new method `start_meet!` that takes a Google meet link.