### PR TITLE
Update channel message

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '2.7.4'
 
 # Load env variables
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.1', '>= 6.0.4.2'
+gem 'rails', '~> 6.1', '>= 6.1.4.4'
 # Use Puma as the app server
 gem 'puma', '~> 4.3'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ DEPENDENCIES
   pry
   puma (~> 4.3)
   rack-test
-  rails (~> 6.1, >= 6.0.4.2)
+  rails (~> 6.1, >= 6.1.4.4)
   rake
   redis
   rspec

--- a/app/models/slack_methods.rb
+++ b/app/models/slack_methods.rb
@@ -72,7 +72,7 @@ class SlackMethods
 
   def self.introduce_incident!(channel_id, tech_lead)
     message = slack_client.chat_postMessage(channel: channel_id,
-                                            text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
+                                            text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CONTACTS']}|Incident contacts>")
     slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
     slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template>.")
   end

--- a/spec/bot/actions/slack_incident_actions_spec.rb
+++ b/spec/bot/actions/slack_incident_actions_spec.rb
@@ -117,7 +117,7 @@ describe 'actions/slack_incident_actions' do
 
   it 'posts advice', vcr: { cassette_name: 'web/chat_postMessage_advice' } do
     rc = client.chat_postMessage(channel: 'C027ZFNML6Q',
-                                 text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CATEGORIES']}|Incident categorisation>")
+                                 text: "Welcome to the incident channel. Please review the following docs:\n> <#{ENV['INCIDENT_PLAYBOOK']}|Incident playbook> \n><#{ENV['INCIDENT_CONTACTS']}|Incident categorisation>")
     expect(rc.message.text).to include 'Welcome to the incident channel.'
   end
 


### PR DESCRIPTION
## Context

We've now moved our incident playbook from a Google Doc and into our [tech docs](https://teacher-services-tech-docs.london.cloudapps.digital/operating-a-service/incident-playbook.html)

## Changes proposed in this pull request

Update the initial message posted to the channel to reference this tech doc and also the incident contacts