### PR TITLE
Revert close command

### DIFF
--- a/bot/slash_commands/close.rb
+++ b/bot/slash_commands/close.rb
@@ -6,11 +6,11 @@ SlackRubyBotServer::Events.configure do |config|
     begin
       if channel_name.include? 'incident'
         message = SlackMethods.post_a_message(channel_id, '<!here> This incident has now closed.')
-        incident = Incident.new(channel_id: channel_id, channel_name: channel_name)
+        channel_calling_incident = Rails.cache.read('channel_calling_incident')
 
-        SlackMethods.pin_a_message(incident.channel_id, message[:ts])
+        SlackMethods.pin_a_message(channel_id, message[:ts])
 
-        SlackMethods.post_a_message(incident.calling_channel, ":white_check_mark: <!channel> The incident in <##{incident.channel_id}> has now closed.")
+        SlackMethods.post_a_message(channel_calling_incident, ":white_check_mark: <!channel> The incident in <##{channel_id}> has now closed.")
 
         { text: 'You’ve closed the incident.' }
       else


### PR DESCRIPTION
## Context

Changed the close command in [#43](https://github.com/DFE-Digital/slack-incident-bot/pull/43) to use the new `Incident` model, unfortunately this isn't currently working so this is to revert it back until the command can be revisited.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->