### PR TITLE
Add Refer serious misconduct service

### DIFF
--- a/lib/view_payloads/incident.json
+++ b/lib/view_payloads/incident.json
@@ -124,7 +124,7 @@
           {
             "text": {
               "type": "plain_text",
-              "text": "Multiple",
+              "text": "Refer serious misconduct",
               "emoji": true
             },
             "value": "value-7"
@@ -132,10 +132,18 @@
           {
             "text": {
               "type": "plain_text",
-              "text": "Other",
+              "text": "Multiple",
               "emoji": true
             },
             "value": "value-8"
+          },
+          {
+            "text": {
+              "type": "plain_text",
+              "text": "Other",
+              "emoji": true
+            },
+            "value": "value-9"
           }
         ]
       }


### PR DESCRIPTION
Add refer as an affected service option when opening an incident.

## Context

We have a new TRA service that we want to use the incident bot for -> 'Refer serious misconduct'

## Changes proposed in this pull request

Add the service name as an option.