### PR TITLE
New redis env variable

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDIS_URL') }
+  config.cache_store = :redis_cache_store, { url: ENV.fetch('REDISCLOUD_URL') }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque


### PR DESCRIPTION
## Context

<img width="598" alt="image" src="https://user-images.githubusercontent.com/47917431/208398644-645afc86-22d9-4128-80a9-a0d13c1f5937.png">

<img width="937" alt="image" src="https://user-images.githubusercontent.com/47917431/208399086-35c4e303-166e-4c3f-962a-6a56a61bf2f6.png">


Heroku removed our free redis add-on, we have a new one now but the env variable has changed