### PR TITLE
Remove the Google Meet link from the thread

### DIFF
--- a/app/models/slack_methods.rb
+++ b/app/models/slack_methods.rb
@@ -77,12 +77,6 @@ class SlackMethods
     slack_client.chat_postMessage(channel: channel_id, text: "<@#{tech_lead}> please make a copy of the <#{ENV['INCIDENT_TEMPLATE']}|incident template>.")
   end
 
-  def self.start_meet!(channel_id, meet_name)
-    message = slack_client.chat_postMessage(channel: channel_id,
-                                            text: "Join the <http://g.co/meet/#{meet_name}|incident meeting>")
-    slack_client.pins_add(channel: channel_id, timestamp: message[:ts])
-  end
-
   def self.open_the_modal(trigger_id, view_payload)
     slack_client.views_open(
       trigger_id: trigger_id,

--- a/bot/actions/slack_incident_actions.rb
+++ b/bot/actions/slack_incident_actions.rb
@@ -13,7 +13,6 @@ class SlackIncidentActions
     threads << Thread.new { SlackMethods.set_channel_details!(channel_id, SlackMethods.summary_for(incident)) }
     threads << Thread.new { SlackMethods.introduce_incident!(channel_id, incident.tech_lead) }
     threads << Thread.new { SlackMethods.notify_channel!(channel_calling_incident, channel_id, incident.title, incident.priority) }
-    threads << Thread.new { SlackMethods.start_meet!(channel_id, incident.title.parameterize) }
 
     threads.each(&:join)
   end

--- a/spec/requests/slack_incident_actions_spec.rb
+++ b/spec/requests/slack_incident_actions_spec.rb
@@ -67,8 +67,8 @@ describe 'actions/slack_incident_actions' do
     expect(conversation_stub).to have_been_requested
     expect(invite_stub).to have_been_requested
     expect(topic_stub).to have_been_requested
-    expect(message_stub).to have_been_requested.times(4)
-    expect(pin_stub).to have_been_requested.times(2)
+    expect(message_stub).to have_been_requested.times(3)
+    expect(pin_stub).to have_been_requested.times(1)
   end
 
   it 'performs the update action' do


### PR DESCRIPTION
We no longer use Google Workspace and tend to just use Slack Huddles on the channel instead.
